### PR TITLE
Fix compilation issues with updated dependencies

### DIFF
--- a/api-extractor/src/main/java/com/yourco/extractor/BeanValidationSupport.java
+++ b/api-extractor/src/main/java/com/yourco/extractor/BeanValidationSupport.java
@@ -41,12 +41,27 @@ public final class BeanValidationSupport {
   }
 
   private boolean hasAny(ResolvedFieldDeclaration field, String... annotations) {
-    for (String name : annotations) {
-      if (field.hasAnnotation(name)) {
-        return true;
+    Optional<FieldDeclaration> ast = toAst(field);
+    if (ast.isEmpty()) {
+      return false;
+    }
+    for (AnnotationExpr annotation : ast.get().getAnnotations()) {
+      for (String candidate : annotations) {
+        if (annotationMatches(annotation, candidate)) {
+          return true;
+        }
       }
     }
     return false;
+  }
+
+  private boolean annotationMatches(AnnotationExpr annotation, String target) {
+    String fullName = annotation.getNameAsString();
+    String simpleName = annotation.getName().getIdentifier();
+    if (target.equals(fullName) || target.equals(simpleName)) {
+      return true;
+    }
+    return target.endsWith("." + simpleName);
   }
 
   private void applySize(ResolvedFieldDeclaration field, Schema<?> schema) {

--- a/api-extractor/src/main/java/com/yourco/extractor/ExtractorConfig.java
+++ b/api-extractor/src/main/java/com/yourco/extractor/ExtractorConfig.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 
@@ -32,11 +33,13 @@ public final class ExtractorConfig {
 
   public static ExtractorConfig load(Path path) throws IOException {
     Objects.requireNonNull(path, "config path");
-    Constructor constructor = new Constructor(ExtractorConfig.class);
+    LoaderOptions loaderOptions = new LoaderOptions();
+    Constructor constructor = new Constructor(ExtractorConfig.class, loaderOptions);
     Yaml yaml = new Yaml(constructor);
     ExtractorConfig config;
     try (InputStream in = Files.newInputStream(path)) {
-      config = Optional.ofNullable(yaml.load(in)).orElseGet(ExtractorConfig::new);
+      ExtractorConfig loaded = yaml.loadAs(in, ExtractorConfig.class);
+      config = loaded != null ? loaded : new ExtractorConfig();
     }
     config.baseDir = path.toAbsolutePath().getParent();
     config.applyDefaults();

--- a/api-extractor/src/main/java/com/yourco/extractor/OpenApiBuilder.java
+++ b/api-extractor/src/main/java/com/yourco/extractor/OpenApiBuilder.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -133,11 +134,14 @@ public final class OpenApiBuilder {
     if (meta == null) {
       return inner;
     }
-    return meta.getSchemaTemplate()
-        .map(template -> applyWrapperTemplate(meta, template, inner))
-        .orElse(inner);
+    Optional<Map<String, Object>> template = meta.getSchemaTemplate();
+    if (template.isEmpty()) {
+      return inner;
+    }
+    return applyWrapperTemplate(meta, template.get(), inner);
   }
 
+  @SuppressWarnings("unchecked")
   private Schema<?> applyWrapperTemplate(
       WrapperMeta meta, Map<String, Object> template, Schema<?> inner) {
     if (template == null || template.isEmpty()) {

--- a/api-extractor/src/main/java/com/yourco/extractor/ProjectClasspath.java
+++ b/api-extractor/src/main/java/com/yourco/extractor/ProjectClasspath.java
@@ -37,7 +37,7 @@ public final class ProjectClasspath {
     for (Path jar : config.getClasspathEntries()) {
       try {
         LOGGER.debug("Adding jar: {}", jar);
-        solver.add(JarTypeSolver.getJarTypeSolver(jar));
+        solver.add(new JarTypeSolver(jar));
       } catch (IOException ex) {
         LOGGER.warn("Failed to add jar {} to classpath: {}", jar, ex.getMessage());
       }

--- a/api-extractor/src/main/java/com/yourco/extractor/SchemaGenerator.java
+++ b/api-extractor/src/main/java/com/yourco/extractor/SchemaGenerator.java
@@ -29,7 +29,7 @@ public final class SchemaGenerator {
   private static final Logger LOGGER = LoggerFactory.getLogger(SchemaGenerator.class);
 
   private final ExtractorConfig config;
-  private final Map<String, Schema<?>> components = new LinkedHashMap<>();
+  private final Map<String, Schema> components = new LinkedHashMap<>();
   private final Set<String> processing = ConcurrentHashMap.newKeySet();
   private final JacksonSupport jacksonSupport = new JacksonSupport();
   private final BeanValidationSupport validationSupport = new BeanValidationSupport();
@@ -42,7 +42,7 @@ public final class SchemaGenerator {
     return toSchema(type, 0);
   }
 
-  public Map<String, Schema<?>> getComponents() {
+  public Map<String, Schema> getComponents() {
     return components;
   }
 
@@ -91,10 +91,11 @@ public final class SchemaGenerator {
       }
       ResolvedReferenceType ref = type.asReferenceType();
       try {
-        ResolvedReferenceTypeDeclaration declaration = ref.getTypeDeclaration();
-        if (declaration == null) {
+        Optional<ResolvedReferenceTypeDeclaration> declarationOpt = ref.getTypeDeclaration();
+        if (declarationOpt.isEmpty()) {
           return objectSchema();
         }
+        ResolvedReferenceTypeDeclaration declaration = declarationOpt.get();
         if (declaration.isEnum()) {
           return registerEnum(type, declaration.asEnum());
         }
@@ -199,7 +200,7 @@ public final class SchemaGenerator {
     ObjectSchema schema = new ObjectSchema();
     components.put(name, schema);
     Set<String> required = new LinkedHashSet<>();
-    Map<String, Schema<?>> properties = new LinkedHashMap<>();
+    Map<String, Schema> properties = new LinkedHashMap<>();
     Set<String> seen = new LinkedHashSet<>();
     try {
       for (ResolvedFieldDeclaration field : declaration.getAllFields()) {

--- a/api-extractor/src/main/java/com/yourco/extractor/types/JavaType.java
+++ b/api-extractor/src/main/java/com/yourco/extractor/types/JavaType.java
@@ -81,7 +81,7 @@ public final class JavaType {
       return List.of();
     }
     ResolvedReferenceType referenceType = resolvedType.asReferenceType();
-    List<ResolvedType> values = new ArrayList<>(referenceType.getTypeParametersValues());
+    List<ResolvedType> values = new ArrayList<>(referenceType.typeParametersValues());
     return values.stream().map(JavaType::from).collect(Collectors.toUnmodifiableList());
   }
 
@@ -89,7 +89,7 @@ public final class JavaType {
     if (!isReferenceType()) {
       return this;
     }
-    return new JavaType(resolvedType.asReferenceType().getErasedType());
+    return new JavaType(resolvedType.asReferenceType().erasure());
   }
 
   public Optional<JavaType> getFirstTypeArgument() {

--- a/api-extractor/src/main/java/com/yourco/extractor/types/Types.java
+++ b/api-extractor/src/main/java/com/yourco/extractor/types/Types.java
@@ -1,5 +1,6 @@
 package com.yourco.extractor.types;
 
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.types.ResolvedPrimitiveType;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import java.util.List;
@@ -35,7 +36,12 @@ public final class Types {
 
   private static boolean implementsInterface(ResolvedReferenceType ref, String iface) {
     return ref.getAllAncestors().stream()
-        .filter(ResolvedReferenceType::isInterface)
+        .filter(
+            ancestor ->
+                ancestor
+                    .getTypeDeclaration()
+                    .map(ResolvedReferenceTypeDeclaration::isInterface)
+                    .orElse(false))
         .anyMatch(ancestor -> ancestor.getQualifiedName().equals(iface));
   }
 


### PR DESCRIPTION
## Summary
- switch annotation detection in Jackson and bean validation helpers to AST-based checks compatible with javaparser 3.25.8
- update configuration loading to SnakeYAML 2.x APIs and refresh schema generation to handle new optional type declarations
- adjust type utilities and classpath wiring for the latest symbol solver generics

## Testing
- mvn -f api-extractor/pom.xml package

------
https://chatgpt.com/codex/tasks/task_e_68d3b4a7ddd4832f97c0a9a005da7bd5