### PR TITLE
Improve controller scanning and schema generation

### DIFF
--- a/api-extractor/src/main/java/com/yourco/extractor/ControllerScanner.java
+++ b/api-extractor/src/main/java/com/yourco/extractor/ControllerScanner.java
@@ -4,18 +4,28 @@ import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseProblemException;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.ArrayInitializerExpr;
+import com.github.javaparser.ast.expr.EnclosedExpr;
 import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.MemberValuePair;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.NormalAnnotationExpr;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.type.Type;
+import com.github.javaparser.resolution.declarations.ResolvedAnnotationDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.yourco.extractor.model.Endpoint;
+import com.yourco.extractor.model.EndpointResponse;
 import com.yourco.extractor.model.Param;
 import com.yourco.extractor.model.ParameterLocation;
 import com.yourco.extractor.model.Payload;
@@ -27,9 +37,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.LinkedHashSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -39,7 +53,12 @@ public final class ControllerScanner {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ControllerScanner.class);
 
-  private static final Set<String> MAPPING_ANNOTATIONS =
+  private static final Set<String> CONTROLLER_SIMPLE_NAMES = Set.of("RestController", "Controller");
+  private static final Set<String> CONTROLLER_FQNS =
+      Set.of(
+          "org.springframework.web.bind.annotation.RestController",
+          "org.springframework.stereotype.Controller");
+  private static final Set<String> MAPPING_SIMPLE_NAMES =
       Set.of(
           "RequestMapping",
           "GetMapping",
@@ -47,6 +66,75 @@ public final class ControllerScanner {
           "PutMapping",
           "DeleteMapping",
           "PatchMapping");
+  private static final Set<String> MAPPING_FQNS =
+      Set.of(
+          "org.springframework.web.bind.annotation.RequestMapping",
+          "org.springframework.web.bind.annotation.GetMapping",
+          "org.springframework.web.bind.annotation.PostMapping",
+          "org.springframework.web.bind.annotation.PutMapping",
+          "org.springframework.web.bind.annotation.DeleteMapping",
+          "org.springframework.web.bind.annotation.PatchMapping");
+  private static final Map<String, String> DIRECT_HTTP_METHODS =
+      Map.of(
+          "GetMapping", "GET",
+          "PostMapping", "POST",
+          "PutMapping", "PUT",
+          "DeleteMapping", "DELETE",
+          "PatchMapping", "PATCH");
+  private static final Set<String> STANDARD_HTTP_METHODS =
+      Set.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD");
+  private static final List<String> DEFAULT_JSON_MEDIA = List.of("application/json");
+  private static final List<String> FORM_MEDIA_TYPES = List.of("application/x-www-form-urlencoded");
+  private static final List<String> MULTIPART_MEDIA_TYPES = List.of("multipart/form-data");
+  private static final Set<String> SIMPLE_TYPE_QUALIFIED =
+      Set.of(
+          "java.lang.String",
+          "java.lang.Boolean",
+          "java.lang.Integer",
+          "java.lang.Long",
+          "java.lang.Short",
+          "java.lang.Byte",
+          "java.lang.Double",
+          "java.lang.Float",
+          "java.math.BigDecimal",
+          "java.math.BigInteger",
+          "java.util.UUID",
+          "java.time.LocalDate",
+          "java.time.LocalDateTime",
+          "java.time.LocalTime",
+          "java.time.OffsetDateTime",
+          "java.time.OffsetTime",
+          "java.time.ZonedDateTime",
+          "java.time.Instant",
+          "java.time.Duration",
+          "java.time.Period",
+          "java.util.Date",
+          "java.sql.Date",
+          "java.sql.Timestamp",
+          "java.net.URI",
+          "java.net.URL");
+  private static final Set<String> INFRASTRUCTURE_TYPES =
+      Set.of(
+          "javax.servlet.http.HttpServletRequest",
+          "javax.servlet.http.HttpServletResponse",
+          "jakarta.servlet.http.HttpServletRequest",
+          "jakarta.servlet.http.HttpServletResponse",
+          "javax.servlet.http.HttpSession",
+          "jakarta.servlet.http.HttpSession",
+          "org.springframework.web.context.request.WebRequest",
+          "org.springframework.web.context.request.NativeWebRequest",
+          "org.springframework.web.context.request.ServletWebRequest",
+          "org.springframework.http.server.ServerHttpRequest",
+          "org.springframework.http.server.ServerHttpResponse",
+          "org.springframework.security.core.Authentication",
+          "java.security.Principal",
+          "org.springframework.validation.BindingResult",
+          "org.springframework.ui.Model",
+          "org.springframework.ui.ModelMap",
+          "org.springframework.web.servlet.ModelAndView",
+          "org.springframework.http.HttpHeaders");
+  private static final Set<String> IGNORED_PARAMETER_ANNOTATIONS =
+      Set.of("RequestAttribute", "SessionAttribute");
 
   private final ProjectClasspath classpath;
   private final ExtractorConfig config;
@@ -112,14 +200,20 @@ public final class ControllerScanner {
   }
 
   private boolean isController(ClassOrInterfaceDeclaration clazz) {
-    return hasAnnotation(clazz, "RestController") || hasAnnotation(clazz, "Controller");
+    for (AnnotationExpr annotation : clazz.getAnnotations()) {
+      if (isControllerAnnotation(annotation, new HashSet<>())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private List<Endpoint> extractEndpoints(ClassOrInterfaceDeclaration clazz, String packageName) {
     MappingInfo classMapping = findMapping(clazz).orElse(MappingInfo.empty());
-    List<String> classPaths = defaultIfEmpty(classMapping.paths, List.of(""));
-    List<String> classConsumes = defaultIfEmpty(classMapping.consumes, List.of());
-    List<String> classProduces = defaultIfEmpty(classMapping.produces, List.of());
+    List<String> classPaths = defaultIfEmpty(classMapping.paths(), List.of(""));
+    List<String> classConsumes = defaultIfEmpty(classMapping.consumes(), List.of());
+    List<String> classProduces = defaultIfEmpty(classMapping.produces(), List.of());
+    Optional<ResponseStatusInfo> classResponseStatus = findResponseStatus(clazz);
 
     List<Endpoint> endpoints = new ArrayList<>();
     for (MethodDeclaration method : clazz.getMethods()) {
@@ -131,10 +225,10 @@ public final class ControllerScanner {
         continue;
       }
       MappingInfo mapping = mappingOpt.get();
-      List<String> httpMethods = defaultIfEmpty(mapping.methods, List.of("GET"));
-      List<String> methodPaths = defaultIfEmpty(mapping.paths, List.of(""));
-      List<String> consumes = mapping.consumes.isEmpty() ? classConsumes : mapping.consumes;
-      List<String> produces = mapping.produces.isEmpty() ? classProduces : mapping.produces;
+      List<String> httpMethods = defaultIfEmpty(mapping.methods(), List.of("GET"));
+      List<String> methodPaths = defaultIfEmpty(mapping.paths(), List.of(""));
+      List<String> consumes = mapping.consumes().isEmpty() ? classConsumes : mapping.consumes();
+      List<String> produces = mapping.produces().isEmpty() ? classProduces : mapping.produces();
       List<String> normalizedConsumes = Util.normalizeMediaTypes(consumes, config);
       List<String> normalizedProduces = Util.normalizeMediaTypes(produces, config);
 
@@ -142,18 +236,27 @@ public final class ControllerScanner {
       List<Param> params = new ArrayList<>();
 
       for (Parameter parameter : method.getParameters()) {
-        ParameterDescriptor descriptor = describeParameter(parameter);
+        ParameterDescriptor descriptor = describeParameter(parameter, httpMethods);
         if (descriptor == null) {
           continue;
         }
         if (descriptor.isRequestBody()) {
+          if (requestBody != null) {
+            LOGGER.debug(
+                "Skipping additional request body parameter {} on {}.{}",
+                parameter.getNameAsString(),
+                clazz.getNameAsString(),
+                method.getNameAsString());
+            continue;
+          }
           JavaType type = descriptor.getJavaType();
           if (type == null) {
             continue;
           }
-          List<String> mediaTypes = normalizedConsumes.isEmpty()
-              ? List.of("application/json")
-              : normalizedConsumes;
+          List<String> mediaTypes =
+              descriptor.getMediaTypes().isEmpty()
+                  ? (normalizedConsumes.isEmpty() ? DEFAULT_JSON_MEDIA : normalizedConsumes)
+                  : Util.normalizeMediaTypes(descriptor.getMediaTypes(), config);
           requestBody =
               Payload.builder()
                   .javaType(type)
@@ -179,21 +282,42 @@ public final class ControllerScanner {
         }
       }
 
-      JavaType responseType = resolveType(method.getType()).orElse(null);
-      if (responseType == null || responseType.isVoid()) {
-        responseType = resolveObjectType();
+      JavaType rawResponseType = resolveType(method.getType()).orElse(null);
+      JavaType payloadType = null;
+      WrapperMeta wrapperMeta = null;
+      if (rawResponseType != null) {
+        payloadType = wrapperStripper.strip(rawResponseType);
+        wrapperMeta = wrapperStripper.meta(rawResponseType).orElse(null);
+        if (isVoidLike(payloadType)) {
+          payloadType = null;
+          wrapperMeta = null;
+        }
       }
-      JavaType payloadType = wrapperStripper.strip(responseType);
-      Optional<WrapperMeta> wrapperMeta = wrapperStripper.meta(responseType);
-      List<String> responseMedia = normalizedProduces.isEmpty()
-          ? List.of("application/json")
-          : normalizedProduces;
-      Payload responsePayload =
-          Payload.builder()
-              .javaType(payloadType)
-              .mediaTypes(responseMedia)
-              .required(false)
-              .wrapperMeta(wrapperMeta.orElse(null))
+      if (payloadType == null && rawResponseType == null) {
+        payloadType = resolveObjectType();
+      }
+      Payload responsePayload = null;
+      if (payloadType != null) {
+        List<String> responseMedia =
+            normalizedProduces.isEmpty() ? DEFAULT_JSON_MEDIA : normalizedProduces;
+        responsePayload =
+            Payload.builder()
+                .javaType(payloadType)
+                .mediaTypes(responseMedia)
+                .required(false)
+                .wrapperMeta(wrapperMeta)
+                .build();
+      }
+
+      ResponseStatusInfo responseStatus =
+          findResponseStatus(method)
+              .orElseGet(() -> classResponseStatus.orElse(ResponseStatusInfo.ok()));
+
+      EndpointResponse endpointResponse =
+          EndpointResponse.builder()
+              .statusCode(responseStatus.statusCode())
+              .payload(responsePayload)
+              .description(responseStatus.description())
               .build();
 
       for (String classPath : classPaths) {
@@ -209,7 +333,7 @@ public final class ControllerScanner {
                     .fullPath(fullPath)
                     .params(params)
                     .requestBody(requestBody)
-                    .response(responsePayload)
+                    .responses(List.of(endpointResponse))
                     .consumes(normalizedConsumes)
                     .produces(normalizedProduces)
                     .operationId(packageName + "." + method.getNameAsString())
@@ -228,60 +352,67 @@ public final class ControllerScanner {
         .orElseThrow(() -> new IllegalStateException("Unable to resolve java.lang.Object"));
   }
 
-  private ParameterDescriptor describeParameter(Parameter parameter) {
-    List<String> annotationNames =
-        parameter.getAnnotations().stream().map(a -> a.getName().getIdentifier()).collect(Collectors.toList());
-    boolean isPath = contains(annotationNames, "PathVariable");
-    boolean isQuery = contains(annotationNames, "RequestParam");
-    boolean isHeader = contains(annotationNames, "RequestHeader");
-    boolean isCookie = contains(annotationNames, "CookieValue");
-    boolean isBody = contains(annotationNames, "RequestBody");
-    if (!(isPath || isQuery || isHeader || isCookie || isBody)) {
+  private ParameterDescriptor describeParameter(Parameter parameter, List<String> httpMethods) {
+    if (hasIgnoredAnnotation(parameter)) {
       return null;
     }
 
     JavaType type = resolveType(parameter.getType()).orElse(null);
-    if (type == null) {
+    if (type == null || isInfrastructureType(type)) {
       return null;
     }
 
     ParameterDescriptor descriptor = new ParameterDescriptor();
     descriptor.javaType = type;
-    descriptor.requestBody = isBody;
-    descriptor.required = isPath || isBody || isQuery;
-    descriptor.location = ParameterLocation.QUERY;
     descriptor.name = parameter.getNameAsString();
-    if (isPath) {
+    descriptor.required = true;
+    descriptor.location = ParameterLocation.QUERY;
+
+    Optional<AnnotationExpr> path = findAnnotation(parameter, "PathVariable");
+    Optional<AnnotationExpr> matrix = findAnnotation(parameter, "MatrixVariable");
+    Optional<AnnotationExpr> requestParam = findAnnotation(parameter, "RequestParam");
+    Optional<AnnotationExpr> requestHeader = findAnnotation(parameter, "RequestHeader");
+    Optional<AnnotationExpr> cookieValue = findAnnotation(parameter, "CookieValue");
+    Optional<AnnotationExpr> requestBody = findAnnotation(parameter, "RequestBody");
+    Optional<AnnotationExpr> requestPart = findAnnotation(parameter, "RequestPart");
+    Optional<AnnotationExpr> modelAttribute = findAnnotation(parameter, "ModelAttribute");
+
+    if (path.isPresent() || matrix.isPresent()) {
       descriptor.location = ParameterLocation.PATH;
+      descriptor.requestBody = false;
       descriptor.required = true;
-    } else if (isQuery) {
+      applyNamedParameterAttributes(descriptor, path.orElseGet(matrix::get));
+    } else if (requestParam.isPresent()) {
       descriptor.location = ParameterLocation.QUERY;
-    } else if (isHeader) {
+      descriptor.requestBody = false;
+      applyNamedParameterAttributes(descriptor, requestParam.get());
+    } else if (requestHeader.isPresent()) {
       descriptor.location = ParameterLocation.HEADER;
-    } else if (isCookie) {
+      descriptor.requestBody = false;
+      applyNamedParameterAttributes(descriptor, requestHeader.get());
+    } else if (cookieValue.isPresent()) {
       descriptor.location = ParameterLocation.COOKIE;
-    } else if (isBody) {
+      descriptor.requestBody = false;
+      applyNamedParameterAttributes(descriptor, cookieValue.get());
+    } else if (requestBody.isPresent()) {
+      descriptor.requestBody = true;
       descriptor.location = null;
+      descriptor.required =
+          extractBooleanAttribute(requestBody.get(), "required").orElse(true);
+    } else if (requestPart.isPresent()) {
+      descriptor.requestBody = true;
+      descriptor.location = null;
+      descriptor.mediaTypes = new ArrayList<>(MULTIPART_MEDIA_TYPES);
+      applyNamedParameterAttributes(descriptor, requestPart.get());
+    } else if (modelAttribute.isPresent()) {
+      descriptor.requestBody = true;
+      descriptor.location = null;
+      descriptor.mediaTypes = new ArrayList<>(FORM_MEDIA_TYPES);
+    } else {
+      classifyImplicitParameter(descriptor, type, httpMethods);
     }
 
-    parameter
-        .getAnnotations()
-        .forEach(
-            annotation -> {
-              String name = annotation.getName().getIdentifier();
-              if (name.equals("PathVariable") || name.equals("RequestParam") || name.equals("RequestHeader") || name.equals("CookieValue")) {
-                descriptor.name = extractStringAttribute(annotation, "value").orElse(descriptor.name);
-                descriptor.name = extractStringAttribute(annotation, "name").orElse(descriptor.name);
-                descriptor.required =
-                    extractBooleanAttribute(annotation, "required").orElse(descriptor.required);
-                descriptor.defaultValue = extractStringAttribute(annotation, "defaultValue").orElse(null);
-              }
-              if (name.equals("RequestBody")) {
-                descriptor.required =
-                    extractBooleanAttribute(annotation, "required").orElse(descriptor.required);
-              }
-            });
-    if (descriptor.defaultValue != null) {
+    if (descriptor.defaultValue != null && !descriptor.defaultValue.isEmpty()) {
       descriptor.required = false;
     }
     return descriptor;
@@ -294,6 +425,37 @@ public final class ControllerScanner {
       LOGGER.debug("Failed to resolve type {}: {}", type, ex.getMessage());
       return Optional.empty();
     }
+  }
+
+  private boolean isControllerAnnotation(AnnotationExpr annotation, Set<String> visited) {
+    String identifier = annotation.getName().getIdentifier();
+    if (CONTROLLER_SIMPLE_NAMES.contains(identifier)) {
+      return true;
+    }
+    try {
+      return isControllerAnnotation(annotation.resolve(), visited);
+    } catch (RuntimeException ex) {
+      LOGGER.debug("Failed to resolve controller annotation {}: {}", annotation, ex.getMessage());
+      return false;
+    }
+  }
+
+  private boolean isControllerAnnotation(
+      ResolvedAnnotationDeclaration resolved, Set<String> visited) {
+    String qualified = resolved.getQualifiedName();
+    if (!visited.add(qualified)) {
+      return false;
+    }
+    if (CONTROLLER_SIMPLE_NAMES.contains(resolved.getName())
+        || CONTROLLER_FQNS.contains(qualified)) {
+      return true;
+    }
+    for (ResolvedAnnotationDeclaration meta : resolved.getAnnotations()) {
+      if (isControllerAnnotation(meta, visited)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private Optional<MappingInfo> findMapping(MethodDeclaration method) {
@@ -314,21 +476,47 @@ public final class ControllerScanner {
     return Optional.empty();
   }
 
-  private boolean hasAnnotation(ClassOrInterfaceDeclaration clazz, String simpleName) {
-    return clazz.getAnnotations().stream().anyMatch(a -> a.getName().getIdentifier().equals(simpleName));
-  }
-
   private boolean isMappingAnnotation(AnnotationExpr annotation) {
     String identifier = annotation.getName().getIdentifier();
-    return MAPPING_ANNOTATIONS.contains(identifier);
+    if (MAPPING_SIMPLE_NAMES.contains(identifier)) {
+      return true;
+    }
+    try {
+      return isMappingAnnotation(annotation.resolve(), new HashSet<>());
+    } catch (RuntimeException ex) {
+      LOGGER.debug("Failed to resolve mapping annotation {}: {}", annotation, ex.getMessage());
+      return false;
+    }
+  }
+
+  private boolean isMappingAnnotation(
+      ResolvedAnnotationDeclaration resolved, Set<String> visited) {
+    String qualified = resolved.getQualifiedName();
+    if (!visited.add(qualified)) {
+      return false;
+    }
+    if (MAPPING_SIMPLE_NAMES.contains(resolved.getName()) || MAPPING_FQNS.contains(qualified)) {
+      return true;
+    }
+    for (ResolvedAnnotationDeclaration meta : resolved.getAnnotations()) {
+      if (isMappingAnnotation(meta, visited)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private MappingInfo parseMapping(AnnotationExpr annotation) {
-    MappingInfo info = new MappingInfo();
-    String identifier = annotation.getName().getIdentifier();
-    if (!identifier.equals("RequestMapping")) {
-      info.methods.add(identifier.replace("Mapping", "").toUpperCase());
+    MappingInfo info = parseMappingInternal(annotation);
+    mergeMetaMapping(annotation, info, new HashSet<>());
+    if (info.methods().isEmpty()) {
+      info.methods.addAll(httpMethodsFromName(annotation.getName().getIdentifier()));
     }
+    return info;
+  }
+
+  private MappingInfo parseMappingInternal(AnnotationExpr annotation) {
+    MappingInfo info = new MappingInfo();
     if (annotation.isSingleMemberAnnotationExpr()) {
       info.paths.addAll(extractValues(annotation.asSingleMemberAnnotationExpr().getMemberValue()));
     } else if (annotation.isNormalAnnotationExpr()) {
@@ -354,7 +542,54 @@ public final class ControllerScanner {
         }
       }
     }
+    if (info.methods.isEmpty()) {
+      info.methods.addAll(httpMethodsFromName(annotation.getName().getIdentifier()));
+    }
     return info;
+  }
+
+  private void mergeMetaMapping(AnnotationExpr annotation, MappingInfo target, Set<String> visited) {
+    try {
+      ResolvedAnnotationDeclaration resolved = annotation.resolve();
+      mergeMetaMapping(resolved, target, visited);
+    } catch (RuntimeException ex) {
+      LOGGER.debug("Failed to resolve meta mapping for {}: {}", annotation, ex.getMessage());
+    }
+  }
+
+  private void mergeMetaMapping(
+      ResolvedAnnotationDeclaration resolved, MappingInfo target, Set<String> visited) {
+    String qualified = resolved.getQualifiedName();
+    if (!visited.add(qualified)) {
+      return;
+    }
+    resolved
+        .toAst()
+        .ifPresent(
+            decl -> {
+              NodeList<AnnotationExpr> annotations = decl.getAnnotations();
+              for (AnnotationExpr meta : annotations) {
+                if (isMappingAnnotation(meta)) {
+                  MappingInfo metaInfo = parseMappingInternal(meta);
+                  target.methods.addAll(metaInfo.methods());
+                  if (target.paths.isEmpty()) {
+                    target.paths.addAll(metaInfo.paths());
+                  }
+                  if (target.consumes.isEmpty()) {
+                    target.consumes.addAll(metaInfo.consumes());
+                  }
+                  if (target.produces.isEmpty()) {
+                    target.produces.addAll(metaInfo.produces());
+                  }
+                  mergeMetaMapping(meta, target, visited);
+                }
+              }
+            });
+    for (ResolvedAnnotationDeclaration meta : resolved.getAnnotations()) {
+      if (isMappingAnnotation(meta, new HashSet<>())) {
+        mergeMetaMapping(meta, target, visited);
+      }
+    }
   }
 
   private List<String> extractMethodValues(Expression value) {
@@ -427,15 +662,238 @@ public final class ControllerScanner {
     return list == null || list.isEmpty() ? defaultList : list;
   }
 
-  private boolean contains(List<String> names, String target) {
-    return names.stream().anyMatch(name -> name.equals(target));
+  private List<String> httpMethodsFromName(String identifier) {
+    if (identifier == null) {
+      return List.of();
+    }
+    if (DIRECT_HTTP_METHODS.containsKey(identifier)) {
+      return List.of(DIRECT_HTTP_METHODS.get(identifier));
+    }
+    String upper = identifier.toUpperCase(Locale.ROOT);
+    for (String method : STANDARD_HTTP_METHODS) {
+      if (upper.startsWith(method)) {
+        return List.of(method);
+      }
+    }
+    return List.of();
+  }
+
+  private boolean hasIgnoredAnnotation(Parameter parameter) {
+    for (AnnotationExpr annotation : parameter.getAnnotations()) {
+      if (IGNORED_PARAMETER_ANNOTATIONS.contains(annotation.getName().getIdentifier())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private Optional<AnnotationExpr> findAnnotation(Parameter parameter, String simpleName) {
+    return parameter.getAnnotations().stream()
+        .filter(annotation -> annotation.getName().getIdentifier().equals(simpleName))
+        .findFirst();
+  }
+
+  private void applyNamedParameterAttributes(
+      ParameterDescriptor descriptor, AnnotationExpr annotation) {
+    descriptor.name = extractStringAttribute(annotation, "value").orElse(descriptor.name);
+    descriptor.name = extractStringAttribute(annotation, "name").orElse(descriptor.name);
+    descriptor.required =
+        extractBooleanAttribute(annotation, "required").orElse(descriptor.required);
+    descriptor.defaultValue = extractStringAttribute(annotation, "defaultValue").orElse(null);
+  }
+
+  private void classifyImplicitParameter(
+      ParameterDescriptor descriptor, JavaType type, List<String> httpMethods) {
+    if (isSimpleType(type)) {
+      descriptor.location = ParameterLocation.QUERY;
+      descriptor.requestBody = false;
+      descriptor.required = true;
+      return;
+    }
+    if (!allowsRequestBody(httpMethods)) {
+      descriptor.location = ParameterLocation.QUERY;
+      descriptor.requestBody = false;
+      descriptor.required = false;
+      return;
+    }
+    descriptor.requestBody = true;
+    descriptor.location = null;
+    descriptor.mediaTypes = new ArrayList<>(FORM_MEDIA_TYPES);
+  }
+
+  private boolean allowsRequestBody(List<String> httpMethods) {
+    if (httpMethods == null || httpMethods.isEmpty()) {
+      return true;
+    }
+    for (String method : httpMethods) {
+      String normalized = method == null ? "" : method.toUpperCase(Locale.ROOT);
+      if (!normalized.equals("GET") && !normalized.equals("DELETE") && !normalized.equals("HEAD")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isInfrastructureType(JavaType type) {
+    if (!type.isReferenceType()) {
+      return false;
+    }
+    return INFRASTRUCTURE_TYPES.contains(type.getQualifiedName());
+  }
+
+  private boolean isSimpleType(JavaType type) {
+    if (type.isPrimitive()) {
+      return true;
+    }
+    if (!type.isReferenceType()) {
+      return false;
+    }
+    String qualifiedName = type.getQualifiedName();
+    if (SIMPLE_TYPE_QUALIFIED.contains(qualifiedName)) {
+      return true;
+    }
+    try {
+      Optional<ResolvedReferenceTypeDeclaration> declaration =
+          type.asReferenceType().getTypeDeclaration();
+      return declaration.isPresent() && declaration.get().isEnum();
+    } catch (RuntimeException ex) {
+      LOGGER.debug("Failed to inspect type {}: {}", type.describe(), ex.getMessage());
+      return false;
+    }
+  }
+
+  private boolean isVoidLike(JavaType type) {
+    if (type == null) {
+      return true;
+    }
+    if (type.isVoid()) {
+      return true;
+    }
+    if (type.isReferenceType() && "java.lang.Void".equals(type.getQualifiedName())) {
+      return true;
+    }
+    return false;
+  }
+
+  private Optional<ResponseStatusInfo> findResponseStatus(ClassOrInterfaceDeclaration clazz) {
+    return findResponseStatus((NodeWithAnnotations<?>) clazz);
+  }
+
+  private Optional<ResponseStatusInfo> findResponseStatus(MethodDeclaration method) {
+    return findResponseStatus((NodeWithAnnotations<?>) method);
+  }
+
+  private Optional<ResponseStatusInfo> findResponseStatus(NodeWithAnnotations<?> node) {
+    for (AnnotationExpr annotation : node.getAnnotations()) {
+      if (annotation.getName().getIdentifier().equals("ResponseStatus")) {
+        return parseResponseStatus(annotation);
+      }
+    }
+    return Optional.empty();
+  }
+
+  private Optional<ResponseStatusInfo> parseResponseStatus(AnnotationExpr annotation) {
+    Optional<String> statusCode = Optional.empty();
+    Optional<String> reason = Optional.empty();
+    if (annotation.isSingleMemberAnnotationExpr()) {
+      statusCode = parseStatusCode(annotation.asSingleMemberAnnotationExpr().getMemberValue());
+    } else if (annotation.isNormalAnnotationExpr()) {
+      NormalAnnotationExpr normal = annotation.asNormalAnnotationExpr();
+      for (MemberValuePair pair : normal.getPairs()) {
+        switch (pair.getNameAsString()) {
+          case "value":
+          case "code":
+            statusCode = parseStatusCode(pair.getValue());
+            break;
+          case "reason":
+            reason = expressionToString(pair.getValue());
+            break;
+          default:
+            break;
+        }
+      }
+    }
+    if (statusCode.isEmpty()) {
+      return Optional.empty();
+    }
+    String code = statusCode.get();
+    String description = reason.orElseGet(() -> HttpStatusLookup.defaultReason(code).orElse(null));
+    return Optional.of(new ResponseStatusInfo(code, description));
+  }
+
+  private Optional<String> parseStatusCode(Expression expression) {
+    if (expression == null) {
+      return Optional.empty();
+    }
+    if (expression.isFieldAccessExpr()) {
+      FieldAccessExpr fieldAccess = expression.asFieldAccessExpr();
+      String constant = fieldAccess.getName().getIdentifier();
+      return HttpStatusLookup.findByConstant(constant).map(entry -> Integer.toString(entry.code()));
+    }
+    if (expression.isNameExpr()) {
+      String constant = expression.asNameExpr().getName().getIdentifier();
+      return HttpStatusLookup.findByConstant(constant).map(entry -> Integer.toString(entry.code()));
+    }
+    if (expression.isIntegerLiteralExpr()) {
+      return Optional.of(expression.asIntegerLiteralExpr().getValue());
+    }
+    if (expression.isMethodCallExpr()) {
+      MethodCallExpr call = expression.asMethodCallExpr();
+      if (!call.getArguments().isEmpty()) {
+        return parseStatusCode(call.getArgument(0));
+      }
+    }
+    if (expression.isEnclosedExpr()) {
+      EnclosedExpr enclosed = expression.asEnclosedExpr();
+      return parseStatusCode(enclosed.getInner());
+    }
+    return Optional.empty();
+  }
+
+  private static final class ResponseStatusInfo {
+    private final String statusCode;
+    private final String description;
+
+    ResponseStatusInfo(String statusCode, String description) {
+      this.statusCode = statusCode;
+      this.description = description;
+    }
+
+    static ResponseStatusInfo ok() {
+      String reason = HttpStatusLookup.defaultReason("200").orElse("OK");
+      return new ResponseStatusInfo("200", reason);
+    }
+
+    String statusCode() {
+      return statusCode;
+    }
+
+    String description() {
+      return description;
+    }
   }
 
   private static final class MappingInfo {
-    final List<String> paths = new ArrayList<>();
-    final List<String> methods = new ArrayList<>();
-    final List<String> consumes = new ArrayList<>();
-    final List<String> produces = new ArrayList<>();
+    final Set<String> paths = new LinkedHashSet<>();
+    final Set<String> methods = new LinkedHashSet<>();
+    final Set<String> consumes = new LinkedHashSet<>();
+    final Set<String> produces = new LinkedHashSet<>();
+
+    List<String> paths() {
+      return new ArrayList<>(paths);
+    }
+
+    List<String> methods() {
+      return new ArrayList<>(methods);
+    }
+
+    List<String> consumes() {
+      return new ArrayList<>(consumes);
+    }
+
+    List<String> produces() {
+      return new ArrayList<>(produces);
+    }
 
     static MappingInfo empty() {
       return new MappingInfo();
@@ -449,6 +907,7 @@ public final class ControllerScanner {
     private JavaType javaType;
     private boolean requestBody;
     private String defaultValue;
+    private List<String> mediaTypes = new ArrayList<>();
 
     public String getName() {
       return name;
@@ -472,6 +931,10 @@ public final class ControllerScanner {
 
     public String getDefaultValue() {
       return defaultValue;
+    }
+
+    public List<String> getMediaTypes() {
+      return new ArrayList<>(mediaTypes);
     }
   }
 }

--- a/api-extractor/src/main/java/com/yourco/extractor/HttpStatusLookup.java
+++ b/api-extractor/src/main/java/com/yourco/extractor/HttpStatusLookup.java
@@ -1,0 +1,113 @@
+package com.yourco.extractor;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+public final class HttpStatusLookup {
+
+  private static final Map<String, Entry> BY_CONSTANT = new LinkedHashMap<>();
+  private static final Map<Integer, Entry> BY_CODE = new LinkedHashMap<>();
+
+  private HttpStatusLookup() {}
+
+  public static Optional<Entry> findByConstant(String constant) {
+    if (constant == null || constant.isBlank()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(BY_CONSTANT.get(constant.toUpperCase(Locale.ROOT)));
+  }
+
+  public static Optional<Entry> findByCode(int code) {
+    return Optional.ofNullable(BY_CODE.get(code));
+  }
+
+  public static Optional<String> defaultReason(String code) {
+    if (code == null) {
+      return Optional.empty();
+    }
+    try {
+      return findByCode(Integer.parseInt(code)).map(Entry::reason);
+    } catch (NumberFormatException ex) {
+      return Optional.empty();
+    }
+  }
+
+  private static void register(int code, String reason, String... constantNames) {
+    Entry entry = new Entry(code, reason);
+    for (String name : constantNames) {
+      if (name != null) {
+        BY_CONSTANT.put(name.toUpperCase(Locale.ROOT), entry);
+      }
+    }
+    BY_CODE.putIfAbsent(code, entry);
+  }
+
+  static {
+    register(100, "Continue", "CONTINUE");
+    register(101, "Switching Protocols", "SWITCHING_PROTOCOLS");
+    register(102, "Processing", "PROCESSING");
+    register(103, "Early Hints", "EARLY_HINTS", "CHECKPOINT");
+    register(200, "OK", "OK");
+    register(201, "Created", "CREATED");
+    register(202, "Accepted", "ACCEPTED");
+    register(203, "Non-Authoritative Information", "NON_AUTHORITATIVE_INFORMATION");
+    register(204, "No Content", "NO_CONTENT");
+    register(205, "Reset Content", "RESET_CONTENT");
+    register(206, "Partial Content", "PARTIAL_CONTENT");
+    register(207, "Multi-Status", "MULTI_STATUS");
+    register(208, "Already Reported", "ALREADY_REPORTED");
+    register(226, "IM Used", "IM_USED");
+    register(300, "Multiple Choices", "MULTIPLE_CHOICES");
+    register(301, "Moved Permanently", "MOVED_PERMANENTLY");
+    register(302, "Found", "FOUND");
+    register(303, "See Other", "SEE_OTHER");
+    register(304, "Not Modified", "NOT_MODIFIED");
+    register(305, "Use Proxy", "USE_PROXY");
+    register(307, "Temporary Redirect", "TEMPORARY_REDIRECT");
+    register(308, "Permanent Redirect", "PERMANENT_REDIRECT");
+    register(400, "Bad Request", "BAD_REQUEST");
+    register(401, "Unauthorized", "UNAUTHORIZED");
+    register(402, "Payment Required", "PAYMENT_REQUIRED");
+    register(403, "Forbidden", "FORBIDDEN");
+    register(404, "Not Found", "NOT_FOUND");
+    register(405, "Method Not Allowed", "METHOD_NOT_ALLOWED");
+    register(406, "Not Acceptable", "NOT_ACCEPTABLE");
+    register(407, "Proxy Authentication Required", "PROXY_AUTHENTICATION_REQUIRED");
+    register(408, "Request Timeout", "REQUEST_TIMEOUT");
+    register(409, "Conflict", "CONFLICT");
+    register(410, "Gone", "GONE");
+    register(411, "Length Required", "LENGTH_REQUIRED");
+    register(412, "Precondition Failed", "PRECONDITION_FAILED");
+    register(413, "Payload Too Large", "PAYLOAD_TOO_LARGE");
+    register(414, "URI Too Long", "URI_TOO_LONG");
+    register(415, "Unsupported Media Type", "UNSUPPORTED_MEDIA_TYPE");
+    register(416, "Requested Range Not Satisfiable", "REQUESTED_RANGE_NOT_SATISFIABLE");
+    register(417, "Expectation Failed", "EXPECTATION_FAILED");
+    register(418, "I'm a teapot", "I_AM_A_TEAPOT");
+    register(421, "Misdirected Request", "MISDIRECTED_REQUEST");
+    register(422, "Unprocessable Content", "UNPROCESSABLE_ENTITY");
+    register(423, "Locked", "LOCKED");
+    register(424, "Failed Dependency", "FAILED_DEPENDENCY");
+    register(425, "Too Early", "TOO_EARLY");
+    register(426, "Upgrade Required", "UPGRADE_REQUIRED");
+    register(428, "Precondition Required", "PRECONDITION_REQUIRED");
+    register(429, "Too Many Requests", "TOO_MANY_REQUESTS");
+    register(431, "Request Header Fields Too Large", "REQUEST_HEADER_FIELDS_TOO_LARGE");
+    register(451, "Unavailable For Legal Reasons", "UNAVAILABLE_FOR_LEGAL_REASONS");
+    register(500, "Internal Server Error", "INTERNAL_SERVER_ERROR");
+    register(501, "Not Implemented", "NOT_IMPLEMENTED");
+    register(502, "Bad Gateway", "BAD_GATEWAY");
+    register(503, "Service Unavailable", "SERVICE_UNAVAILABLE");
+    register(504, "Gateway Timeout", "GATEWAY_TIMEOUT");
+    register(505, "HTTP Version Not Supported", "HTTP_VERSION_NOT_SUPPORTED");
+    register(506, "Variant Also Negotiates", "VARIANT_ALSO_NEGOTIATES");
+    register(507, "Insufficient Storage", "INSUFFICIENT_STORAGE");
+    register(508, "Loop Detected", "LOOP_DETECTED");
+    register(510, "Not Extended", "NOT_EXTENDED");
+    register(511, "Network Authentication Required", "NETWORK_AUTHENTICATION_REQUIRED");
+  }
+
+  public record Entry(int code, String reason) {}
+}

--- a/api-extractor/src/main/java/com/yourco/extractor/PolymorphismSupport.java
+++ b/api-extractor/src/main/java/com/yourco/extractor/PolymorphismSupport.java
@@ -1,0 +1,195 @@
+package com.yourco.extractor;
+
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.expr.ArrayInitializerExpr;
+import com.github.javaparser.ast.expr.ClassExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.MemberValuePair;
+import com.github.javaparser.ast.expr.NormalAnnotationExpr;
+import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
+import com.yourco.extractor.types.JavaType;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.Discriminator;
+import io.swagger.v3.oas.models.media.Schema;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class PolymorphismSupport {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PolymorphismSupport.class);
+
+  private final ExtractorConfig.PolymorphismConfig config;
+  private final SchemaNaming naming;
+  private final JacksonSupport jacksonSupport;
+  private final JavaParserFacade typeResolver;
+
+  PolymorphismSupport(
+      ExtractorConfig.PolymorphismConfig config,
+      SchemaNaming naming,
+      JacksonSupport jacksonSupport,
+      JavaParserFacade typeResolver) {
+    this.config = config;
+    this.naming = naming;
+    this.jacksonSupport = jacksonSupport;
+    this.typeResolver = typeResolver;
+  }
+
+  Schema<?> apply(
+      JavaType type,
+      ResolvedReferenceTypeDeclaration declaration,
+      Schema<?> schema,
+      Function<JavaType, Schema<?>> schemaResolver) {
+    if (!isEnabled()) {
+      return schema;
+    }
+    List<SubType> subTypes = findJsonSubTypes(declaration);
+    if (subTypes.isEmpty()) {
+      return schema;
+    }
+    ComposedSchema composed = new ComposedSchema();
+    if (schema instanceof io.swagger.v3.oas.models.media.ObjectSchema objectSchema) {
+      if (objectSchema.getProperties() != null && !objectSchema.getProperties().isEmpty()) {
+        composed.addAllOfItem(schema);
+      }
+    } else {
+      composed.addAllOfItem(schema);
+    }
+    List<Schema<?>> oneOf = new ArrayList<>();
+    Map<String, String> mapping = new LinkedHashMap<>();
+    for (SubType subType : subTypes) {
+      Schema<?> child = schemaResolver.apply(subType.javaType());
+      oneOf.add(child);
+      String name = naming.schemaName(subType.javaType());
+      mapping.put(subType.alias(), "#/components/schemas/" + name);
+    }
+    composed.setOneOf(oneOf);
+    Discriminator discriminator = new Discriminator();
+    discriminator.setPropertyName(config.getDiscriminatorProperty());
+    if (!mapping.isEmpty()) {
+      discriminator.setMapping(mapping);
+    }
+    composed.setDiscriminator(discriminator);
+    return composed;
+  }
+
+  private boolean isEnabled() {
+    String strategy = config.getDefault();
+    if (strategy == null) {
+      return false;
+    }
+    return !strategy.equalsIgnoreCase("flat-common");
+  }
+
+  private List<SubType> findJsonSubTypes(ResolvedReferenceTypeDeclaration declaration) {
+    Optional<AnnotationExpr> annotation =
+        jacksonSupport.findTypeAnnotation(declaration, "JsonSubTypes");
+    if (annotation.isEmpty()) {
+      return List.of();
+    }
+    return parseJsonSubTypes(annotation.get());
+  }
+
+  private List<SubType> parseJsonSubTypes(AnnotationExpr annotation) {
+    List<SubType> result = new ArrayList<>();
+    if (annotation.isSingleMemberAnnotationExpr()) {
+      parseTypeExpressions(annotation.asSingleMemberAnnotationExpr().getMemberValue(), result);
+    } else if (annotation.isNormalAnnotationExpr()) {
+      NormalAnnotationExpr normal = annotation.asNormalAnnotationExpr();
+      for (MemberValuePair pair : normal.getPairs()) {
+        if (pair.getNameAsString().equals("value")) {
+          parseTypeExpressions(pair.getValue(), result);
+        }
+      }
+    }
+    return result;
+  }
+
+  private void parseTypeExpressions(Expression expression, List<SubType> result) {
+    for (Expression expr : flatten(expression)) {
+      if (expr.isNormalAnnotationExpr()) {
+        parseTypeAnnotation(expr.asNormalAnnotationExpr(), result);
+      } else if (expr.isSingleMemberAnnotationExpr()) {
+        parseTypeAnnotation(expr.asSingleMemberAnnotationExpr(), result);
+      }
+    }
+  }
+
+  private void parseTypeAnnotation(NormalAnnotationExpr annotation, List<SubType> result) {
+    if (!annotation.getName().getIdentifier().equals("Type")) {
+      return;
+    }
+    Optional<JavaType> type = Optional.empty();
+    Optional<String> alias = Optional.empty();
+    for (MemberValuePair pair : annotation.getPairs()) {
+      switch (pair.getNameAsString()) {
+        case "value":
+          type = resolveClassExpr(pair.getValue());
+          break;
+        case "name":
+          alias = expressionToString(pair.getValue());
+          break;
+        default:
+          break;
+      }
+    }
+    type.ifPresent(t -> result.add(new SubType(t, alias.orElse(simpleAlias(t)))));
+  }
+
+  private void parseTypeAnnotation(SingleMemberAnnotationExpr annotation, List<SubType> result) {
+    if (!annotation.getName().getIdentifier().equals("Type")) {
+      return;
+    }
+    Optional<JavaType> type = resolveClassExpr(annotation.getMemberValue());
+    type.ifPresent(t -> result.add(new SubType(t, simpleAlias(t))));
+  }
+
+  private Optional<JavaType> resolveClassExpr(Expression expression) {
+    if (expression.isClassExpr()) {
+      ClassExpr classExpr = expression.asClassExpr();
+      try {
+        return Optional.of(JavaType.from(typeResolver.convertToUsage(classExpr.getType())));
+      } catch (RuntimeException ex) {
+        LOGGER.debug("Failed to resolve subtype {}: {}", classExpr, ex.getMessage());
+      }
+    }
+    return Optional.empty();
+  }
+
+  private Optional<String> expressionToString(Expression expression) {
+    if (expression.isStringLiteralExpr()) {
+      return Optional.of(expression.asStringLiteralExpr().asString());
+    }
+    return Optional.empty();
+  }
+
+  private List<Expression> flatten(Expression expression) {
+    if (expression.isArrayInitializerExpr()) {
+      ArrayInitializerExpr array = expression.asArrayInitializerExpr();
+      List<Expression> flattened = new ArrayList<>();
+      for (Expression element : array.getValues()) {
+        flattened.addAll(flatten(element));
+      }
+      return flattened;
+    }
+    return List.of(expression);
+  }
+
+  private String simpleAlias(JavaType type) {
+    if (type.isReferenceType()) {
+      String qualified = type.asReferenceType().getQualifiedName();
+      int idx = qualified.lastIndexOf('.');
+      return idx >= 0 ? qualified.substring(idx + 1) : qualified;
+    }
+    return type.describe();
+  }
+
+  private record SubType(JavaType javaType, String alias) {}
+}

--- a/api-extractor/src/main/java/com/yourco/extractor/SchemaNaming.java
+++ b/api-extractor/src/main/java/com/yourco/extractor/SchemaNaming.java
@@ -1,0 +1,152 @@
+package com.yourco.extractor;
+
+import com.yourco.extractor.types.JavaType;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class SchemaNaming {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SchemaNaming.class);
+
+  private final ExtractorConfig.NamingConfig config;
+  private final Map<String, String> typeToName = new HashMap<>();
+  private final Map<String, String> nameToType = new HashMap<>();
+  private final Map<String, Integer> counters = new HashMap<>();
+
+  public SchemaNaming(ExtractorConfig.NamingConfig config) {
+    this.config = Objects.requireNonNull(config, "naming config");
+  }
+
+  public synchronized String schemaName(JavaType type) {
+    String typeId = type == null ? "java.lang.Object" : type.describe();
+    String existing = typeToName.get(typeId);
+    if (existing != null) {
+      return existing;
+    }
+    String baseName = computeBaseName(type);
+    String unique = ensureUnique(baseName, typeId);
+    typeToName.put(typeId, unique);
+    return unique;
+  }
+
+  private String computeBaseName(JavaType type) {
+    String strategy = config.getSchemaName();
+    if (type == null) {
+      return "Object";
+    }
+    if (!type.isReferenceType()) {
+      return sanitize(type.describe());
+    }
+    String normalized = strategy == null ? "" : strategy.toUpperCase(Locale.ROOT);
+    return switch (normalized) {
+      case "FQN" -> sanitize(type.asReferenceType().getQualifiedName());
+      case "SIMPLE_NAME" -> sanitize(simpleName(type));
+      case "SIMPLE_NAME_WITH_TYPEARGS" -> sanitize(simpleNameWithArgs(type));
+      case "FQN_ERASED_WITH_TYPEARGS" -> sanitize(fqnWithArgs(type));
+      default -> sanitize(fqnWithArgs(type));
+    };
+  }
+
+  private String ensureUnique(String baseName, String typeId) {
+    String existingType = nameToType.get(baseName);
+    if (existingType == null) {
+      nameToType.put(baseName, typeId);
+      return baseName;
+    }
+    if (existingType.equals(typeId)) {
+      return baseName;
+    }
+    String collisionStrategy = config.getCollision();
+    String normalized = collisionStrategy == null ? "" : collisionStrategy.toLowerCase(Locale.ROOT);
+    switch (normalized) {
+      case "suffix-number":
+        int counter = counters.getOrDefault(baseName, 0);
+        String candidate;
+        do {
+          counter++;
+          candidate = baseName + "_" + counter;
+        } while (nameToType.containsKey(candidate));
+        counters.put(baseName, counter);
+        nameToType.put(candidate, typeId);
+        return candidate;
+      case "error":
+        throw new IllegalStateException(
+            "Schema name collision for "
+                + baseName
+                + " between "
+                + existingType
+                + " and "
+                + typeId);
+      case "first-wins-log":
+      default:
+        if (!Objects.equals(existingType, typeId)) {
+          LOGGER.warn(
+              "Schema name collision for {} between {} and {}",
+              baseName,
+              existingType,
+              typeId);
+        }
+        return baseName;
+    }
+  }
+
+  private String fqnWithArgs(JavaType type) {
+    StringBuilder sb = new StringBuilder(type.asReferenceType().getQualifiedName());
+    List<JavaType> args = type.getTypeArguments();
+    if (!args.isEmpty()) {
+      sb.append('_');
+      for (JavaType arg : args) {
+        sb.append(shortName(arg)).append('_');
+      }
+    }
+    return trimUnderscore(sb.toString());
+  }
+
+  private String simpleName(JavaType type) {
+    return simpleName(type.asReferenceType().getQualifiedName());
+  }
+
+  private String simpleName(String qualifiedName) {
+    int idx = qualifiedName.lastIndexOf('.');
+    return idx >= 0 ? qualifiedName.substring(idx + 1) : qualifiedName;
+  }
+
+  private String simpleNameWithArgs(JavaType type) {
+    StringBuilder sb = new StringBuilder(simpleName(type));
+    List<JavaType> args = type.getTypeArguments();
+    if (!args.isEmpty()) {
+      sb.append('_');
+      for (JavaType arg : args) {
+        sb.append(shortName(arg)).append('_');
+      }
+    }
+    return trimUnderscore(sb.toString());
+  }
+
+  private String shortName(JavaType type) {
+    if (type.isReferenceType()) {
+      return simpleName(type.asReferenceType().getQualifiedName());
+    }
+    return type.describe();
+  }
+
+  private String trimUnderscore(String value) {
+    if (value.endsWith("_")) {
+      return value.substring(0, value.length() - 1);
+    }
+    return value;
+  }
+
+  private String sanitize(String raw) {
+    return raw.replace('<', '_')
+        .replace('>', '_')
+        .replace(',', '_')
+        .replace('.', '_')
+        .replace(" ", "");
+  }
+}

--- a/api-extractor/src/main/java/com/yourco/extractor/model/Endpoint.java
+++ b/api-extractor/src/main/java/com/yourco/extractor/model/Endpoint.java
@@ -11,7 +11,7 @@ public class Endpoint {
   private final String fullPath;
   private final List<Param> params;
   private final Payload requestBody;
-  private final Payload response;
+  private final List<EndpointResponse> responses;
   private final List<String> consumes;
   private final List<String> produces;
   private final String operationId;
@@ -21,7 +21,7 @@ public class Endpoint {
     this.fullPath = builder.fullPath;
     this.params = Collections.unmodifiableList(new ArrayList<>(builder.params));
     this.requestBody = builder.requestBody;
-    this.response = builder.response;
+    this.responses = Collections.unmodifiableList(new ArrayList<>(builder.responses));
     this.consumes = Collections.unmodifiableList(new ArrayList<>(builder.consumes));
     this.produces = Collections.unmodifiableList(new ArrayList<>(builder.produces));
     this.operationId = builder.operationId;
@@ -43,8 +43,8 @@ public class Endpoint {
     return requestBody;
   }
 
-  public Payload getResponse() {
-    return response;
+  public List<EndpointResponse> getResponses() {
+    return responses;
   }
 
   public List<String> getConsumes() {
@@ -68,7 +68,7 @@ public class Endpoint {
     private String fullPath;
     private List<Param> params = new ArrayList<>();
     private Payload requestBody;
-    private Payload response;
+    private List<EndpointResponse> responses = new ArrayList<>();
     private List<String> consumes = new ArrayList<>();
     private List<String> produces = new ArrayList<>();
     private String operationId;
@@ -100,8 +100,15 @@ public class Endpoint {
       return this;
     }
 
-    public Builder response(Payload response) {
-      this.response = response;
+    public Builder responses(List<EndpointResponse> responses) {
+      this.responses = new ArrayList<>(Objects.requireNonNullElse(responses, List.of()));
+      return this;
+    }
+
+    public Builder addResponse(EndpointResponse response) {
+      if (response != null) {
+        this.responses.add(response);
+      }
       return this;
     }
 

--- a/api-extractor/src/main/java/com/yourco/extractor/model/EndpointResponse.java
+++ b/api-extractor/src/main/java/com/yourco/extractor/model/EndpointResponse.java
@@ -1,0 +1,60 @@
+package com.yourco.extractor.model;
+
+import java.util.Objects;
+
+public class EndpointResponse {
+
+  private final String statusCode;
+  private final Payload payload;
+  private final String description;
+
+  private EndpointResponse(Builder builder) {
+    this.statusCode = builder.statusCode;
+    this.payload = builder.payload;
+    this.description = builder.description;
+  }
+
+  public String getStatusCode() {
+    return statusCode;
+  }
+
+  public Payload getPayload() {
+    return payload;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private String statusCode;
+    private Payload payload;
+    private String description;
+
+    private Builder() {}
+
+    public Builder statusCode(String statusCode) {
+      this.statusCode = statusCode;
+      return this;
+    }
+
+    public Builder payload(Payload payload) {
+      this.payload = payload;
+      return this;
+    }
+
+    public Builder description(String description) {
+      this.description = description;
+      return this;
+    }
+
+    public EndpointResponse build() {
+      Objects.requireNonNull(statusCode, "statusCode");
+      return new EndpointResponse(this);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- expand controller scanning to honor composed annotations, richer parameter hints, and `@ResponseStatus` when building endpoints
- add response modeling infrastructure (EndpointResponse, HttpStatusLookup) and teach the OpenAPI builder to emit multiple responses with default descriptions
- introduce configurable schema naming plus Jackson-driven polymorphism support during schema generation, and enhance ignore path handling with glob matching

## Testing
- mvn -q -DskipTests compile *(fails: unable to reach repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e2b184dc832fa6bf7dbe250a11e9